### PR TITLE
Secret: allow `None` to be used as a default value

### DIFF
--- a/secrets_management/secrets_manager.py
+++ b/secrets_management/secrets_manager.py
@@ -8,6 +8,8 @@ from botocore.exceptions import ClientError
 
 from .util import bool_converter
 
+_not_set = object()
+
 
 class Secret:
     def __init__(self, secret: Dict[str, str], fallback_env: Optional[environ.Env] = None):
@@ -18,7 +20,7 @@ class Secret:
         self,
         key: str,
         allow_env_fallback: bool = False,
-        default: Optional[Any] = None,
+        default: Any = _not_set,
         cast_type: Optional[str] = None,
     ) -> Any:
         """
@@ -41,15 +43,15 @@ class Secret:
         except KeyError:
             if allow_env_fallback:
                 try:
-                    if default is not None:
-                        return self.fallback_env(key, default=default)
-                    else:
+                    if default is _not_set:
                         return self.fallback_env(key)
+                    else:
+                        return self.fallback_env(key, default=default)
                 except TypeError:
                     raise AttributeError("`fallback_env` not set for this secret")
-            if default is not None:
-                return default
-            raise
+            elif default is _not_set:
+                raise
+            return default
 
     def _cast(self, value: str, type_: str):
         """Cast a string value to a given type"""


### PR DESCRIPTION
I ran into this issue again just now on `ukf`, this closes #10

There's no existing test suite, but here's the PR running in Python 3.9:
```python
>>> from secrets_management import Secret
>>> 
>>> secret = Secret(secret={"foo": 1, "bar": None})
>>> secret.get("foo", default=None) == 1
True
>>> secret.get("bar") is None
True
>>> secret.get("foobar", default=None) is None  # Would have previously raised a KeyError
True
>>> secret.get("foobar")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/kevin/code/Work/secrets-management/secrets_management/secrets_manager.py", line 32, in get
    value = self._get(key, allow_env_fallback, default)
  File "/home/kevin/code/Work/secrets-management/secrets_management/secrets_manager.py", line 42, in _get
    return self.secret[key]
KeyError: 'foobar'
```

I changed the order of some of the if statements to avoid having the double negative of "if default is **not** _not_set:"