### PR TITLE
Explicitly set `secret_refresh_interval` to avoid triggering deprecation warning message

### DIFF
--- a/secrets_management/secrets_manager.py
+++ b/secrets_management/secrets_manager.py
@@ -77,7 +77,9 @@ class SecretsManager:
     def __init__(self, region_name: str):
         session = boto3.session.Session()
         client = session.client(service_name="secretsmanager", region_name=region_name)
-        cache_config = SecretCacheConfig()
+        cache_config = SecretCacheConfig(
+            secret_refresh_interval=int(timedelta(hours=1).total_seconds()),
+        )
         self.cache = SecretCache(config=cache_config, client=client)
 
     def retrieve_secret(self, secret_name: str) -> Optional[Secret]:


### PR DESCRIPTION
See the full details in https://github.com/aws/aws-secretsmanager-caching-python/pull/30 but this 1 hour time out is the same as the default value but wrapping it in an `int` so it's `3600` and not `3600.0` so it doesn't trigger the: 

> DeprecationWarning: [non-integer arguments to randrange()](https://docs.python.org/3/whatsnew/3.10.html#deprecated) have been deprecated since Python 3.10

Ideally this would just be fixed upstream but that trivial PR has been sitting there for almost a year so I presume that package is fairly unmaintained.

