### PR TITLE
Add a test suite to the project

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4
@@ -16,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: pip install -e ".[test]"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: Tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: pip install -e ".[test]"
+
+      - name: Run tests
+        run: pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]

--- a/README.md
+++ b/README.md
@@ -53,12 +53,23 @@ SOME_SECRET_NUMBER = secret.get("SOME_SECRET_NUMBER", cast_type="int")
 ```
 Currently supported values are `int`, `float` and `bool`.
 
-## Running the tests
+## Development
 
-Install the package with its test dependencies and run `pytest`:
+For local development, install the package in editable mode together with the test dependencies:
 
 ```bash
 pip install -e ".[test]"
+```
+
+### Running the test suite
+
+Run the full test suite locally with:
+
+```bash
 pytest
 ```
+
+### Continuous integration
+
+The test suite also runs automatically in GitHub Actions for pushes and pull requests via `.github/workflows/tests.yml`.
 

--- a/README.md
+++ b/README.md
@@ -53,3 +53,12 @@ SOME_SECRET_NUMBER = secret.get("SOME_SECRET_NUMBER", cast_type="int")
 ```
 Currently supported values are `int`, `float` and `bool`.
 
+## Running the tests
+
+Install the package with its test dependencies and run `pytest`:
+
+```bash
+pip install -e ".[test]"
+pytest
+```
+

--- a/secrets_management/secrets_manager.py
+++ b/secrets_management/secrets_manager.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Optional
 
 import boto3
 import environ
-from botocore.exceptions import ClientError
 
 from .util import bool_converter
 
@@ -41,13 +40,11 @@ class Secret:
             return self.secret[key]
         except KeyError:
             if allow_env_fallback:
-                try:
-                    if default is _not_set:
-                        return self.fallback_env(key)
-                    else:
-                        return self.fallback_env(key, default=default)
-                except TypeError:
+                if self.fallback_env is None:
                     raise AttributeError("`fallback_env` not set for this secret")
+                if default is _not_set:
+                    return self.fallback_env(key)
+                return self.fallback_env(key, default=default)
             elif default is _not_set:
                 raise
             return default
@@ -84,4 +81,10 @@ class SecretsManager:
         """
         client = boto3.client("secretsmanager", region_name=self.region_name)
         get_secret_value_response = client.get_secret_value(SecretId=secret_name)
+
+        if "SecretString" not in get_secret_value_response:
+            raise ValueError(
+                f"Secret '{secret_name}' does not contain a SecretString (binary secrets are not supported)"
+            )
+
         return Secret(json.loads(get_secret_value_response["SecretString"]))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[tool:pytest]
+testpaths = tests

--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,10 @@ setuptools.setup(
         "boto3",
         "django-environ",
     ],
+    extras_require={
+        "test": [
+            "pytest",
+            "moto",
+        ],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     install_requires=[
         "boto3",
         "django-environ",

--- a/tests/test_secrets_manager.py
+++ b/tests/test_secrets_manager.py
@@ -1,7 +1,10 @@
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import boto3
 import pytest
+from botocore.exceptions import ClientError
+from moto import mock_aws
 
 from secrets_management import Secret, SecretsManager
 
@@ -50,6 +53,30 @@ class TestSecretGet:
         secret = self._make_secret()
         with pytest.raises(ValueError):
             secret.get("KEY", cast_type="list")
+
+    def test_get_cast_to_bool_via_get(self):
+        secret = self._make_secret({"FLAG": "on"})
+        assert secret.get("FLAG", cast_type="bool") is True
+
+    def test_get_cast_failure_raises_value_error(self):
+        """Casting a non-numeric value to int should raise ValueError."""
+        secret = self._make_secret()
+        with pytest.raises(ValueError):
+            secret.get("KEY", cast_type="int")
+
+    def test_get_cast_applied_to_env_fallback_value(self):
+        """The cast is applied to a value retrieved via env fallback."""
+        secret = self._make_secret()
+        mock_env = MagicMock(return_value="7")
+        secret.set_fallback_env(mock_env)
+        assert secret.get("MISSING", allow_env_fallback=True, cast_type="int") == 7
+
+    def test_init_with_fallback_env_uses_it(self):
+        """A fallback_env passed via the constructor is used directly."""
+        mock_env = MagicMock(return_value="env_value")
+        secret = Secret({"KEY": "value"}, fallback_env=mock_env)
+        assert secret.get("MISSING", allow_env_fallback=True) == "env_value"
+        mock_env.assert_called_once_with("MISSING")
 
     def test_get_with_env_fallback_key_present_in_secret(self):
         """When the key exists in the secret, env fallback is not consulted."""
@@ -103,33 +130,35 @@ class TestSecretSetFallbackEnv:
 
 
 class TestSecretsManagerRetrieveSecret:
+    region = "eu-west-2"
+
+    def _create_secret(self, name, payload):
+        client = boto3.client("secretsmanager", region_name=self.region)
+        client.create_secret(Name=name, SecretString=json.dumps(payload))
+
+    @mock_aws
     def test_retrieve_secret_returns_secret_instance(self):
         payload = {"DB_PASSWORD": "supersecret", "API_KEY": "abc123"}
-        mock_response = {"SecretString": json.dumps(payload)}
+        self._create_secret("my/secret/name", payload)
 
-        with patch("boto3.client") as mock_boto_client:
-            mock_client = MagicMock()
-            mock_boto_client.return_value = mock_client
-            mock_client.get_secret_value.return_value = mock_response
-
-            manager = SecretsManager(region_name="eu-west-2")
-            secret = manager.retrieve_secret("my/secret/name")
+        manager = SecretsManager(region_name=self.region)
+        secret = manager.retrieve_secret("my/secret/name")
 
         assert isinstance(secret, Secret)
         assert secret.get("DB_PASSWORD") == "supersecret"
         assert secret.get("API_KEY") == "abc123"
 
-    def test_retrieve_secret_calls_boto3_with_correct_args(self):
-        payload = {"KEY": "value"}
-        mock_response = {"SecretString": json.dumps(payload)}
+    @mock_aws
+    def test_retrieve_missing_secret_raises_client_error(self):
+        manager = SecretsManager(region_name=self.region)
+        with pytest.raises(ClientError):
+            manager.retrieve_secret("does/not/exist")
 
-        with patch("boto3.client") as mock_boto_client:
-            mock_client = MagicMock()
-            mock_boto_client.return_value = mock_client
-            mock_client.get_secret_value.return_value = mock_response
+    @mock_aws
+    def test_retrieve_binary_secret_raises_value_error(self):
+        client = boto3.client("secretsmanager", region_name=self.region)
+        client.create_secret(Name="binary/secret", SecretBinary=b"\x00\x01\x02")
 
-            manager = SecretsManager(region_name="eu-west-2")
-            manager.retrieve_secret("my/secret/name")
-
-        mock_boto_client.assert_called_once_with("secretsmanager", region_name="eu-west-2")
-        mock_client.get_secret_value.assert_called_once_with(SecretId="my/secret/name")
+        manager = SecretsManager(region_name=self.region)
+        with pytest.raises(ValueError, match="does not contain a SecretString"):
+            manager.retrieve_secret("binary/secret")

--- a/tests/test_secrets_manager.py
+++ b/tests/test_secrets_manager.py
@@ -1,0 +1,135 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from secrets_management import Secret, SecretsManager
+
+
+# ---------------------------------------------------------------------------
+# Secret
+# ---------------------------------------------------------------------------
+
+
+class TestSecretGet:
+    """Tests for Secret.get()"""
+
+    def _make_secret(self, data=None):
+        return Secret(data or {"KEY": "value", "NUMBER": "42", "FLAG": "true"})
+
+    def test_get_existing_key(self):
+        secret = self._make_secret()
+        assert secret.get("KEY") == "value"
+
+    def test_get_missing_key_with_default(self):
+        secret = self._make_secret()
+        assert secret.get("MISSING", default="fallback") == "fallback"
+
+    def test_get_missing_key_without_default_raises_key_error(self):
+        secret = self._make_secret()
+        with pytest.raises(KeyError):
+            secret.get("MISSING")
+
+    def test_get_cast_to_int(self):
+        secret = self._make_secret()
+        assert secret.get("NUMBER", cast_type="int") == 42
+
+    def test_get_cast_to_float(self):
+        secret = self._make_secret({"PRICE": "3.14"})
+        assert secret.get("PRICE", cast_type="float") == pytest.approx(3.14)
+
+    def test_get_cast_to_bool_true(self):
+        secret = self._make_secret()
+        assert secret.get("FLAG", cast_type="bool") is True
+
+    def test_get_cast_to_bool_false(self):
+        secret = self._make_secret({"FLAG": "false"})
+        assert secret.get("FLAG", cast_type="bool") is False
+
+    def test_get_invalid_cast_type_raises_value_error(self):
+        secret = self._make_secret()
+        with pytest.raises(ValueError):
+            secret.get("KEY", cast_type="list")
+
+    def test_get_with_env_fallback_key_present_in_secret(self):
+        """When the key exists in the secret, env fallback is not consulted."""
+        secret = self._make_secret()
+        mock_env = MagicMock()
+        secret.set_fallback_env(mock_env)
+        assert secret.get("KEY", allow_env_fallback=True) == "value"
+        mock_env.assert_not_called()
+
+    def test_get_with_env_fallback_key_missing_uses_env(self):
+        """When the key is absent, env fallback is used."""
+        secret = self._make_secret()
+        mock_env = MagicMock(return_value="env_value")
+        secret.set_fallback_env(mock_env)
+        assert secret.get("MISSING", allow_env_fallback=True) == "env_value"
+        mock_env.assert_called_once_with("MISSING")
+
+    def test_get_with_env_fallback_key_missing_uses_default(self):
+        """When the key is absent and a default is given, pass it to the env callable."""
+        secret = self._make_secret()
+        mock_env = MagicMock(return_value="env_default")
+        secret.set_fallback_env(mock_env)
+        result = secret.get("MISSING", allow_env_fallback=True, default="my_default")
+        assert result == "env_default"
+        mock_env.assert_called_once_with("MISSING", default="my_default")
+
+    def test_get_with_env_fallback_but_no_fallback_env_set_raises_attribute_error(self):
+        """Calling allow_env_fallback without setting fallback_env raises AttributeError."""
+        secret = self._make_secret()
+        with pytest.raises(AttributeError, match="`fallback_env` not set"):
+            secret.get("MISSING", allow_env_fallback=True)
+
+
+class TestSecretSetFallbackEnv:
+    def test_set_fallback_env_returns_self(self):
+        secret = Secret({"KEY": "value"})
+        mock_env = MagicMock()
+        result = secret.set_fallback_env(mock_env)
+        assert result is secret
+
+    def test_set_fallback_env_stores_env(self):
+        secret = Secret({"KEY": "value"})
+        mock_env = MagicMock()
+        secret.set_fallback_env(mock_env)
+        assert secret.fallback_env is mock_env
+
+
+# ---------------------------------------------------------------------------
+# SecretsManager
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsManagerRetrieveSecret:
+    def test_retrieve_secret_returns_secret_instance(self):
+        payload = {"DB_PASSWORD": "supersecret", "API_KEY": "abc123"}
+        mock_response = {"SecretString": json.dumps(payload)}
+
+        with patch("boto3.client") as mock_boto_client:
+            mock_client = MagicMock()
+            mock_boto_client.return_value = mock_client
+            mock_client.get_secret_value.return_value = mock_response
+
+            manager = SecretsManager(region_name="eu-west-2")
+            secret = manager.retrieve_secret("my/secret/name")
+
+        assert isinstance(secret, Secret)
+        assert secret.get("DB_PASSWORD") == "supersecret"
+        assert secret.get("API_KEY") == "abc123"
+
+    def test_retrieve_secret_calls_boto3_with_correct_args(self):
+        payload = {"KEY": "value"}
+        mock_response = {"SecretString": json.dumps(payload)}
+
+        with patch("boto3.client") as mock_boto_client:
+            mock_client = MagicMock()
+            mock_boto_client.return_value = mock_client
+            mock_client.get_secret_value.return_value = mock_response
+
+            manager = SecretsManager(region_name="eu-west-2")
+            manager.retrieve_secret("my/secret/name")
+
+        mock_boto_client.assert_called_once_with("secretsmanager", region_name="eu-west-2")
+        mock_client.get_secret_value.assert_called_once_with(SecretId="my/secret/name")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,22 @@
+import pytest
+
+from secrets_management.util import bool_converter
+
+
+TRUTHY_VALUES = [True, 1, "y", "Y", "yes", "YES", "t", "T", "true", "TRUE", "1", "on", "ON"]
+FALSY_VALUES = [False, 0, "n", "N", "no", "NO", "f", "F", "false", "FALSE", "0", "off", "OFF"]
+
+
+class TestBoolConverter:
+    @pytest.mark.parametrize("value", TRUTHY_VALUES)
+    def test_truthy_values_return_true(self, value):
+        assert bool_converter(value) is True
+
+    @pytest.mark.parametrize("value", FALSY_VALUES)
+    def test_falsy_values_return_false(self, value):
+        assert bool_converter(value) is False
+
+    @pytest.mark.parametrize("value", ["maybe", "2", "yep", "nope", "", "tru", "fals"])
+    def test_invalid_values_raise_value_error(self, value):
+        with pytest.raises(ValueError):
+            bool_converter(value)


### PR DESCRIPTION
Closes #14 

The test suite itself was (unsurprisingly) heavily written by agents (a mix of Codex 5.4 and Opus 4.8). It's been quite verbose and tested a lot of potential cases, but they seem to mostly be testing legitimate cases.

While not strictly related, there are a couple of tweaks to some logic which was found during testing.

This also drops support for versions of Python unsupported upstream (< 3.10)