### PR TITLE
Rename workflow and update job configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,6 @@
-name: Tests
+name: Python Tests
 
 on:
-  push:
-    branches: ["**"]
   pull_request:
     branches: ["**"]
 
@@ -10,7 +8,7 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  python-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to clarify its purpose and improve naming consistency.

Workflow configuration improvements:

* Renamed the workflow from `Tests` to `Python Tests` to specify that it is for Python tests.
* Renamed the job from `test` to `python-tests` for better clarity.
* Removed the workflow trigger for `push` events, so the workflow now only runs on pull requests.